### PR TITLE
Implement clutching, refactor code in motion and DirectTeleOperation

### DIFF
--- a/Motion/motion.py
+++ b/Motion/motion.py
@@ -134,10 +134,7 @@ class Motion:
         else:
             logger.error('Wrong Mode specified')
             raise RuntimeError('Wrong Mode specified')
-        self.left_limb_state = LimbState()
-        self.right_limb_state = LimbState()
 
-        self.base_state = BaseState()
         self.left_limb_state = LimbState()
         self.right_limb_state = LimbState()
         self.base_state = BaseState()
@@ -323,9 +320,6 @@ class Motion:
                        self.left_gripper.mark_read()
                     #Send Commands
                     if self.left_limb_enabled:
-                        #debug
-                        # print((self.left_limb_state.commandQueue, self.left_limb_state.impedanceControl))
-
                         if self.left_limb_state.commandQueue:
                             if self.left_limb_state.commandType == 0:
                                 tmp = time.time() - self.left_limb_state.commandQueueTime
@@ -344,15 +338,9 @@ class Motion:
                                 res, target_config = self._left_limb_cartesian_drive(self.left_limb_state.driveTransform)
                                 if res == 0:
                                     #res = 0 means IK has failed completely, 1 means keep trying smaller steps, 2 means success
-                                    #set to position mode...
                                     self.cartesian_drive_failure = True
-                                    self.left_limb_state.commandSent = False
-                                    self.left_limb_state.commandedq = deepcopy(self.sensedLeftLimbPosition())
-                                    self.left_limb_state.commandeddq = []
-                                    self.left_limb_state.commandType = 0
-                                    self.left_limb_state.commandQueue = False
-                                    self.left_limb_state.commandedqQueue = []
-                                    self.left_limb_state.cartesianDrive = False
+                                    #set to position mode...
+                                    self.left_limb_state.set_mode_position(self.sensedLeftLimbPosition())
                                     break
                                 elif res == 1:
                                     flag = 1
@@ -363,13 +351,7 @@ class Motion:
                             res,target_config = self._left_limb_imdepance_drive()
                             if res == 0:
                                 self.cartesian_drive_failure = True
-                                self.left_limb_state.commandSent = False
-                                self.left_limb_state.commandedq = deepcopy(self.sensedLeftLimbPosition())
-                                self.left_limb_state.commandeddq = []
-                                self.left_limb_state.commandType = 0
-                                self.left_limb_state.commandQueue = False
-                                self.left_limb_state.commandedqQueue = []
-                                self.left_limb_state.impedanceControl = False
+                                self.left_limb_state.set_mode_position(self.sensedLeftLimbPosition())
                             elif res == 1:
                                 self.left_limb.setConfig(target_config)
                             elif res == 2:
@@ -401,13 +383,7 @@ class Motion:
                                 if res == 0:
                                     #set to position mode...
                                     self.cartesian_drive_failure = True
-                                    self.right_limb_state.commandSent = False
-                                    self.right_limb_state.commandedq = deepcopy(self.sensedRightLimbPosition())
-                                    self.right_limb_state.commandeddq = []
-                                    self.right_limb_state.commandType = 0
-                                    self.right_limb_state.commandQueue = False
-                                    self.right_limb_state.commandedqQueue = []
-                                    self.right_limb_state.cartesianDrive = False
+                                    self.right_limb_state.set_mode_position(self.sensedRightLimbPosition())
                                     break
                                 elif res == 1:
                                     flag = 1
@@ -418,13 +394,7 @@ class Motion:
                             res,target_config = self._right_limb_imdepance_drive()
                             if res == 0:
                                 self.cartesian_drive_failure = True
-                                self.right_limb_state.commandSent = False
-                                self.right_limb_state.commandedq = deepcopy(self.sensedRightLimbPosition())
-                                self.right_limb_state.commandeddq = []
-                                self.right_limb_state.commandType = 0
-                                self.right_limb_state.commandQueue = False
-                                self.right_limb_state.commandedqQueue = []
-                                self.right_limb_state.impedanceControl = False
+                                self.right_limb_state.set_mode_position(self.sensedRightLimbPosition())
                             elif res == 1:
                                 self.right_limb.setConfig(target_config)
                             elif res == 2:
@@ -508,16 +478,7 @@ class Motion:
                             if res == 0:
                                 #set to position mode...
                                 self.cartesian_drive_failure = True
-                                self.left_limb_state.commandSent = False
-                                self.left_limb_state.commandedq = deepcopy(self.sensedLeftLimbPosition())
-                                self.left_limb_state.commandeddq = []
-                                self.left_limb_state.commandType = 0
-                                self.left_limb_state.commandQueue = False
-                                self.left_limb_state.difference = []
-                                self.left_limb_state.commandedqQueueStart = []
-                                self.left_limb_state.commandQueueTime = 0.0
-                                self.left_limb_state.commandedQueueDuration = 0.0
-                                self.left_limb_state.cartesianDrive = False
+                                self.left_limb_state.set_mode_position(self.sensedLeftLimbPosition())
                                 break
                             elif res == 1:
                                 flag = 1
@@ -553,16 +514,7 @@ class Motion:
                             if res == 0:
                                 #set to position mode...
                                 self.cartesian_drive_failure = True
-                                self.right_limb_state.commandSent = False
-                                self.right_limb_state.commandedq = deepcopy(self.sensedRightLimbPosition())
-                                self.right_limb_state.commandeddq = []
-                                self.right_limb_state.commandType = 0
-                                self.right_limb_state.commandQueue = False
-                                self.right_limb_state.difference = []
-                                self.right_limb_state.commandedqQueueStart = []
-                                self.right_limb_state.commandQueueTime = 0.0
-                                self.right_limb_state.commandedQueueDuration = 0.0
-                                self.right_limb_state.cartesianDrive = False
+                                self.right_limb_state.set_mode_position(self.sensedRightLimbPosition())
                                 break
                             elif res == 1:
                                 flag = 1
@@ -649,19 +601,9 @@ class Motion:
         assert len(q) == 6, "motion.setLeftLimbPosition(): Wrong number of joint positions sent"('controlThread exited.')
         if self.left_limb_enabled:
             self._controlLoopLock.acquire()
+            # TODO ????? (Jing-Chen)
             self._check_collision_linear_adaptive(self.robot_model,self._get_klampt_q(left_limb = self.left_limb_state.sensedq),self._get_klampt_q(left_limb = q))
-            self.left_limb_state.commandSent = False
-            self.left_limb_state.commandedq = deepcopy(q)
-            self.left_limb_state.commandeddq = []
-            self.left_limb_state.commandType = 0
-            self.left_limb_state.commandQueue = False
-            self.left_limb_state.difference = []
-            self.left_limb_state.commandedqQueueStart = []
-            self.left_limb_state.commandQueueTime = 0.0
-            self.left_limb_state.commandedQueueDuration = 0.0
-            self.left_limb_state.cartesianDrive = False
-            self.left_limb_state.impedanceControl = False
-            self.left_limb_state.Xs = []
+            self.left_limb_state.set_mode_position(q)
             self._controlLoopLock.release()
         else:
             logger.warning('Left limb not enabled')
@@ -681,19 +623,9 @@ class Motion:
         assert len(q) == 6, "motion.setLeftLimbPosition(): Wrong number of joint positions sent"
         if self.right_limb_enabled:
             self._controlLoopLock.acquire()
+            # TODO ????? (Jing-Chen)
             self._check_collision_linear_adaptive(self.robot_model,self._get_klampt_q(right_limb = self.right_limb_state.sensedq),self._get_klampt_q(right_limb = q))
-            self.right_limb_state.commandSent = False
-            self.right_limb_state.commandedq = deepcopy(q)
-            self.right_limb_state.commandeddq = []
-            self.right_limb_state.commandType = 0
-            self.right_limb_state.commandQueue = False
-            self.right_limb_state.difference = []
-            self.right_limb_state.commandedqQueueStart = []
-            self.right_limb_state.commandQueueTime = 0.0
-            self.right_limb_state.commandedQueueDuration = 0.0
-            self.right_limb_state.cartesianDrive = False
-            self.right_limb_state.impedanceControl = False
-            self.right_limb_state.Xs = []
+            self.right_limb_state.set_mode_position(q)
             self._controlLoopLock.release()
         else:
             logger.warning('Right limb not enabled')
@@ -717,6 +649,7 @@ class Motion:
         #TODO:Also collision checks
         if self.left_limb_enabled:
             self._controlLoopLock.acquire()
+            # NOTE: Why are we running collision checks and tossing the results? WHY? (Jing-Chen)
             self._check_collision_linear_adaptive(self.robot_model,self._get_klampt_q(left_limb = self.left_limb_state.sensedq),self._get_klampt_q(left_limb = q))
             #planningTime = 0.0 + TRINAConfig.ur5e_control_rate
             #positionQueue = []
@@ -726,18 +659,9 @@ class Motion:
             #    positionQueue.append(vectorops.add(currentq,vectorops.mul(difference,planningTime/duration)))
             #    planningTime = planningTime + self.dt #TRINAConfig.ur5e_control_rate
             #positionQueue.append(q)
-            self.left_limb_state.commandSent = False
-            self.left_limb_state.commandType = 0
-            self.left_limb_state.difference = vectorops.sub(q,self.left_limb_state.sensedq)
-            self.left_limb_state.commandedqQueueStart = deepcopy(self.left_limb_state.sensedq)
-            self.left_limb_state.commandQueue = True
-            self.left_limb_state.commandedq = []
-            self.left_limb_state.commandeddq = []
-            self.left_limb_state.cartesianDrive = False
-            self.left_limb_state.impedanceControl = False
-            self.left_limb_state.Xs = []
-            self.left_limb_state.commandedQueueDuration = duration
-            self.left_limb_state.commandQueueTime = time.time()
+            difference = vectorops.sub(q,self.left_limb_state.sensedq)
+            start = self.left_limb_state.sensedq
+            self.left_limb_state.set_mode_commandqueue(difference, start, duration)
             self._controlLoopLock.release()
         else:
             logger.warning('Left limb not enabled')
@@ -761,19 +685,11 @@ class Motion:
         #Also collision checks
         if self.right_limb_enabled:
             self._controlLoopLock.acquire()
+            # NOTE: Why are we running collision checks and tossing the results? WHY? (Jing-Chen)
             self._check_collision_linear_adaptive(self.robot_model,self._get_klampt_q(right_limb = self.right_limb_state.sensedq),self._get_klampt_q(right_limb = q))
-            self.right_limb_state.commandSent = False
-            self.right_limb_state.commandType = 0
-            self.right_limb_state.difference = vectorops.sub(q,self.right_limb_state.sensedq)
-            self.right_limb_state.commandedqQueueStart = deepcopy(self.right_limb_state.sensedq)
-            self.right_limb_state.commandQueue = True
-            self.right_limb_state.commandedq = []
-            self.right_limb_state.commandeddq = []
-            self.right_limb_state.cartesianDrive = False
-            self.right_limb_state.impedanceControl = False
-            self.right_limb_state.Xs = []
-            self.right_limb_state.commandedQueueDuration = duration
-            self.right_limb_state.commandQueueTime = time.time()
+            difference = vectorops.sub(q,self.right_limb_state.sensedq)
+            start = self.right_limb_state.sensedq
+            self.right_limb_state.set_mode_commandqueue(difference, start, duration)
             self._controlLoopLock.release()
         else:
             logger.warning('Right limb not enabled')
@@ -831,18 +747,7 @@ class Motion:
             logger.debug('number of joint velocities sent : %d', len(qdot))
             assert len(qdot) == 6, "motion.setLeftLimbVelocity()): Wrong number of joint velocities sent"
             self._controlLoopLock.acquire()
-            self.left_limb_state.commandSent = False
-            self.left_limb_state.commandeddq = deepcopy(qdot)
-            self.left_limb_state.commandedq = []
-            self.left_limb_state.commandType = 1
-            self.left_limb_state.commandQueue = False
-            self.left_limb_state.difference = []
-            self.left_limb_state.commandedqQueueStart = []
-            self.left_limb_state.commandQueueTime = 0.0
-            self.left_limb_state.commandedQueueDuration = 0.0
-            self.left_limb_state.cartesianDrive = False
-            self.left_limb_state.impedanceControl = False
-            self.left_limb_state.Xs = []
+            self.left_limb_state.set_mode_velocity(qdot)
             self._controlLoopLock.release()
         else:
             logger.warning('Left limb not enabled')
@@ -861,17 +766,7 @@ class Motion:
             logger.debug('number of joint velocities sent : %d', len(qdot))
             assert len(qdot) == 6, "motion.setRightLimbVelocity()): Wrong number of joint velocities sent"
             self._controlLoopLock.acquire()
-            self.right_limb_state.commandSent = False
-            self.right_limb_state.commandeddq = deepcopy(qdot)
-            self.right_limb_state.commandedq = []
-            self.right_limb_state.commandType = 1
-            self.right_limb_state.commandQueue = False
-            self.right_limb_state.difference = []
-            self.right_limb_state.commandedqQueueStart = []
-            self.right_limb_state.commandQueueTime = 0.0
-            self.right_limb_state.commandedQueueDuration = 0.0
-            self.right_limb_state.cartesianDrive = False
-            self.right_limb_state.impedanceControl = False
+            self.right_limb_state.set_mode_velocity(qdot)
             self._controlLoopLock.release()
         else:
             logger.warning('Right limb not enabled')
@@ -943,16 +838,10 @@ class Motion:
         """
         if self.left_limb_enabled:
             self._controlLoopLock.acquire()
-            self.left_limb_state.impedanceControl = False
-            self.left_limb_state.Xs = []
+            #self.left_limb_state.impedanceControl = False
+            #self.left_limb_state.Xs = []
             if not self.left_limb_state.cartesianDrive:
-                self.left_limb_state.commandedq = []
-                self.left_limb_state.commandeddq = []
-                self.left_limb_state.commandQueue = False
-                self.left_limb_state.difference = []
-                self.left_limb_state.commandedqQueueStart = []
-                self.left_limb_state.commandQueueTime = 0.0
-                self.left_limb_state.commandedQueueDuration = 0.0
+                self.left_limb_state.set_mode_position(self.sensedLeftLimbPosition())
                 self.cartesian_drive_failure = False
                 ##cartesian velocity drive
 
@@ -1067,16 +956,10 @@ class Motion:
         """
         if self.right_limb_enabled:
             self._controlLoopLock.acquire()
-            self.right_limb_state.impedanceControl = False
-            self.right_limb_state.Xs = []
+            #self.right_limb_state.impedanceControl = False
+            #self.right_limb_state.Xs = []
             if not self.right_limb_state.cartesianDrive:
-                self.right_limb_state.commandedq = []
-                self.right_limb_state.commandeddq = []
-                self.right_limb_state.commandQueue = False
-                self.right_limb_state.difference = []
-                self.right_limb_state.commandedqQueueStart = []
-                self.right_limb_state.commandQueueTime = 0.0
-                self.right_limb_state.commandedQueueDuration = 0.0
+                self.right_limb_state.set_mode_position(self.sensedRightLimbPosition())
                 self.cartesian_drive_failure = False
                 ##cartesian velocity drive
                 if len(v) == 3:
@@ -1175,12 +1058,14 @@ class Motion:
             self.right_limb_state.x_mass = T[1] + so3.moment(T[0])
             (v,w) = self.sensedRightEEVelocity()
             self.right_limb_state.x_dot_mass = v+w
+
+        self.right_limb_state.set_mode_reset()
+
+        self.right_limb_state.impedanceControl = True
         self.right_limb_state.x_g = Tg[1] + so3.moment(Tg[0])
         self.right_limb_state.x_dot_g = copy(x_dot_g)
         self.right_limb_state.K = copy(K)
-        self.right_limb_state.cartesianDrive = False
-        self.right_limb_state.commandQueue = False
-        self.right_limb_state.impedanceControl = True
+
         self.right_limb_state.counter = 1
         self.right_limb_state.deadband = copy(deadband)
         if np.any(np.isnan(B)):
@@ -1242,13 +1127,15 @@ class Motion:
             self.left_limb_state.x_mass = T[1] + so3.moment(T[0])
             (v,w) = self.sensedLeftEEVelocity()
             self.left_limb_state.x_dot_mass = v+w
+
+        self.left_limb_state.set_mode_reset()
+
+        self.left_limb_state.impedanceControl = True
+
         #self.left_limb_state.T_g = copy(Tg)
         self.left_limb_state.x_g = Tg[1] + so3.moment(Tg[0])
         self.left_limb_state.x_dot_g = copy(x_dot_g)
         self.left_limb_state.K = copy(K)
-        self.left_limb_state.cartesianDrive = False
-        self.left_limb_state.commandQueue = False
-        self.left_limb_state.impedanceControl = True
         self.left_limb_state.counter = 1
         self.left_limb_state.deadband = copy(deadband)
         if np.any(np.isnan(B)):
@@ -2075,9 +1962,9 @@ class Motion:
                 jacobian = np.array(self.left_EE_link.getJacobian([0,0,0]))
                 del_theta = np.linalg.lstsq(jacobian, np.array(se3.error(target_transform, current_transform)))[0]
                 del_theta = 0.1 * del_theta / np.linalg.norm(del_theta)
-                logger.error(str(jacobian))
-                logger.error(str(np.array(se3.error(target_transform, current_transform))))
-                logger.error(str(del_theta))
+                #logger.error(str(jacobian))
+                #logger.error(str(np.array(se3.error(target_transform, current_transform))))
+                #logger.error(str(del_theta))
                 target_config = initialConfig[:]
                 for i, ind in enumerate(self.left_active_Dofs):
                     target_config[ind] += del_theta[ind]

--- a/Motion/motionStates.py
+++ b/Motion/motionStates.py
@@ -1,3 +1,6 @@
+import copy
+import time
+
 class LimbState:
     def __init__(self):
         self.sensedq = [0.0,0.0,0.0,0.0,0.0,0.0]
@@ -18,6 +21,8 @@ class LimbState:
         #for kinematic to use...
         self.lastSensedq = []
 
+        #TODO: This is completely unused... forward declaring it in prep for python 3 transition (Jing-Chen)
+        self.Xs = []
 
         ##cartesian velocity drive
         self.cartesianDrive = False
@@ -44,6 +49,44 @@ class LimbState:
         self.counter = 1
         #range for ignoring the wrench readings
         self.deadband = [0]*6
+
+    def set_mode_reset(self):
+        #self.commandSent = True
+        self.commandedq = []
+        self.commandeddq = []
+        self.commandType = 0
+        self.commandQueue = False
+        self.commandedqQueue = []
+        self.cartesianDrive = False
+        self.impedanceControl = False
+        self.commandQueueTime = 0.0
+        self.commandedQueueDuration = 0.0
+        self.difference = []
+        self.commandedqQueueStart = []
+        self.Xs = []
+
+    def set_mode_position(self, position):
+        self.set_mode_reset()
+
+        self.commandSent = False
+        self.commandedq = copy.deepcopy(position)
+
+    def set_mode_commandqueue(self, difference, start, duration):
+        self.set_mode_reset()
+
+        self.commandSent = False
+        self.difference = difference
+        self.commandedqQueueStart = copy.deepcopy(start)
+        self.commandQueue = True
+        self.commandedQueueDuration = duration
+        self.commandQueueTime = time.time()
+
+    def set_mode_velocity(self, qdot):
+        self.set_mode_reset()
+
+        self.commandSent = False
+        self.commandeddq = copy.deepcopy(qdot)
+        self.commandType = 1
 
 
 class BaseState():

--- a/Testing/scripts/clutching_test.py
+++ b/Testing/scripts/clutching_test.py
@@ -1,0 +1,68 @@
+from reem.connection import RedisInterface
+from reem.datatypes import KeyValueStore
+import time
+import math
+
+import sys
+import os
+path = os.path.expanduser('~/TRINA/')
+sys.path.append(path)
+from Jarvis import Jarvis
+sys.path.remove(path)
+
+
+interface = RedisInterface(host="localhost")
+interface.initialize()
+server = KeyValueStore(interface)
+
+def setup():
+    robot = Jarvis("testing")
+    
+    leftUntuckedConfig = [-0.2028,-2.1063,-1.610,3.7165,-0.9622,0.0974]
+    rightUntuckedConfig = robot.mirror_arm_config(leftUntuckedConfig)
+    robot.setLeftLimbPositionLinear(leftUntuckedConfig,0.1)
+    robot.setRightLimbPositionLinear(rightUntuckedConfig,0.1)
+    
+    try:
+        retval = input("Press enter to continue")
+    except:
+        pass
+    
+    stime = time.time()
+    while time.time() - stime < 15:
+        time.sleep(0.1)
+        server['UI_STATE']["controllerButtonState"]['leftController']["press"] = [True, False, False, False]
+        print("Sending home signal")
+    server['UI_STATE']["controllerButtonState"]['leftController']["press"] = [False, False, False, False]
+
+setup()
+
+side = 'left'
+    
+server['UI_STATE']["controllerPositionState"][side+'Controller']['controllerPosition'] = [0,0,0]
+server['UI_STATE']["controllerPositionState"][side+'Controller']['controllerRotation'] = [1,0,0,0,1,0,0,0,1]
+time.sleep(1)
+
+dt = 0.02
+
+for i in range(3):
+    try:
+        retval = input("Press enter to go up")
+    except:
+        pass
+    t = 0
+    server['UI_STATE']["controllerButtonState"]['leftController']["squeeze"] = [0, 1, 0, 0]
+    for i in range(50):
+        server['UI_STATE']["controllerPositionState"][side+'Controller']['controllerPosition'] = [0.1 * t*dt, 0, 0]
+        t += 1
+        time.sleep(dt)
+    try:
+        retval = input("Press enter to go down")
+    except:
+        pass
+    
+    server['UI_STATE']["controllerButtonState"]['leftController']["squeeze"] = [0, 0, 0, 0]
+    for i in range(50):
+        server['UI_STATE']["controllerPositionState"][side+'Controller']['controllerPosition'] = [0.1 * t*dt, 0, 0]
+        t -= 1
+        time.sleep(dt)

--- a/command_server.py
+++ b/command_server.py
@@ -635,7 +635,8 @@ class CommandLogger(object):
 	def log_command(self,command,time):
 		self.length = self.r.llen(self.key)
 		if(self.length >= self.max_length):
-			print('\n\n\n\n\nQUEUE OVERFLOW!!!! \n\n\n\n\n SOMETHING WRONG WITH THE LOGGER?')
+			print('QUEUE OVERFLOW!!!! SOMETHING WRONG WITH THE LOGGER?')
+			#print('\n\n\n\n\nQUEUE OVERFLOW!!!! \n\n\n\n\n SOMETHING WRONG WITH THE LOGGER?')
 		else:
 			self.r.rpush(self.key,str([command,time]))
 

--- a/trina_modules/DirectTeleOperationModule/DirectTeleOperationFile.py
+++ b/trina_modules/DirectTeleOperationModule/DirectTeleOperationFile.py
@@ -25,12 +25,18 @@ from klampt.math import so3, so2, se3, vectorops
 
 from robot_v2 import robot as controller_listen
 
+from enum import Enum
+
+class ControllerMode(Enum):
+    ABSOLUTE=0
+    CLUTCHING=1
+
 robot_ip = 'http://localhost:8080'
 
 
 ws_port = 1234
 
-model_name = "Motion/data/TRINA_world_seed.xml"
+#model_name = "Motion/data/TRINA_world_seed.xml"
 
 roomname = "The Lobby"
 zonename = "BasicExamples"
@@ -38,8 +44,30 @@ userId=0
 roomId=-1
 is_closed=0
 
+mode="Physical" # UNUSED FOR ANYTHING
+
+class TeleopArmState:
+	def __init__(self, side, active, gripper_active, transform_sensor, transform_setter,
+						proportional_controller, impedance_controller):
+		self.side = side
+		self.joystick = side + "Controller"
+		self.active = active
+		self.gripper_active = gripper_active
+		self.init_pos = None
+		self.cur_pos = None
+		self.sensedEETransform = transform_sensor
+		self.setEEInertialTransform = transform_setter
+		self.setEEVelocity = proportional_controller
+		self.setEETransformImpedance = impedance_controller
+
+		self.teleoperationState = 0
+
 class DirectTeleOperation:
-	def __init__(self,Jarvis = None, debugging = False, mode = 'Physical'):
+	"""
+	mode: Robot (physical) or simulation (absolute)
+	controller_mode: Absolute or Clutching
+	"""
+	def __init__(self,Jarvis = None, debugging = False, mode = mode, controller_mode = ControllerMode.CLUTCHING):
 		self.mode = mode
 		self.status = 'idle' #states are " idle, active"
 		self.state = 'idle' #states are " idle, active"
@@ -51,11 +79,19 @@ class DirectTeleOperation:
 		self.robot = Jarvis
 		self.components =  ['base','left_limb','right_limb','left_gripper']
 		#self.robot.getComponents()
-		self.left_limb_active = ('left_limb' in self.components)
-		self.right_limb_active = ('right_limb' in self.components)
+		left_limb_active = ('left_limb' in self.components)
+		left_gripper_active = ('left_gripper' in self.components)
+		self.left_limb = TeleopArmState("left", left_limb_active, left_gripper_active,
+										self.robot.sensedLeftEETransform, self.robot.setLeftEEInertialTransform,
+										self.robot.setLeftEEVelocity, self.robot.setLeftEETransformImpedance)
+
+		right_limb_active = ('right_limb' in self.components)
+		right_gripper_active = ('right_gripper' in self.components)
+		self.right_limb = TeleopArmState("right", right_limb_active, right_gripper_active, 
+										self.robot.sensedRightEETransform, self.robot.setRightEEInertialTransform,
+										self.robot.setRightEEVelocity, self.robot.setRightEETransformImpedance)
+
 		self.base_active = ('base' in self.components)
-		self.left_gripper_active = ('left_gripper' in self.components)
-		self.right_gripper_active = ('right_gripper' in self.components)
 		self.torso_active = ('torso' in self.components)
 		self.temp_robot_telemetry = {'leftArm':[0,0,0,0,0,0],'rightArm':[0,0,0,0,0,0]}
 
@@ -67,21 +103,22 @@ class DirectTeleOperation:
 		self.B = self.B.tolist()
 
 		#TODO VERY VERY TEMPORARY @REMOVE - Jing-Chen
-		self.tool = np.array([0,0,0])
-		self.tool_target = np.array([0.27,0,0])
+		self.tool = np.array([0.0,0.0,0.0], dtype=np.float64)
+		self.tool_target = np.array([0.27,0.0,0.0])
 
 		# 0 - Go home
 		# 1 - Set controller home
 		# 2 - Move hands
-		self.teleoperationState = 0
+		# Folded into arm objects.
+		# self.teleoperationState = 0
+
+		# Absolute - Home position, everything relative to that
+		# Clutching - Relative to when you last hit clutch
+		self.controller_mode = controller_mode
 
 		time.sleep(5)
 		self.UI_state = {}
-		self.init_pos_left = {}
-		self.cur_pos_left = {}
-		self.init_pos_right = {}
 		self.init_headset_orientation = {}
-		self.cur_pos_right = {}
 		self.startup = True
 		signal.signal(signal.SIGINT, self.sigint_handler) # catch SIGINT (ctrl+c)
 
@@ -139,11 +176,12 @@ class DirectTeleOperation:
 			print('started the initial values for the variables')
 			self.init_UI_state = self.robot.getUIState()
 			self.startup = False
-			if(self.left_limb_active):
-				self.init_pos_left = self.robot.sensedLeftEETransform()
-			if(self.right_limb_active):
-				self.init_pos_right = self.robot.sensedRightEETransform()
+			if(self.left_limb.active):
+				self.left_limb.init_pos = self.left_limb.sensedEETransform()
+			if(self.right_limb.active):
+				self.right_limb.init_pos = self.right_limb.sensedEETransform()
 			self.init_headset_orientation = self.treat_headset_orientation(self.init_UI_state['headSetPositionState']['deviceRotation'])
+
 		while(True):
 			if self.state == 'idle':
 				# print("_serveStateReceiver: idling")
@@ -151,10 +189,10 @@ class DirectTeleOperation:
 			elif self.state == 'active':
 				# print('_serveStateReceiver:active')
 				self.last_time = time.time()
-				if(self.left_limb_active):
-					self.cur_pos_left = self.robot.sensedLeftEETransform()
-				if(self.right_limb_active):
-					self.cur_pos_right = self.robot.sensedRightEETransform()
+				if(self.left_limb.active):
+					self.left_limb.cur_pos = self.right_limb.sensedEETransform()
+				if(self.right_limb.active):
+					self.right_limb.cur_pos = self.right_limb.sensedEETransform()
 				self.UI_state = self.robot.getUIState()
 				self.UIStateLogic()
 				time.sleep(self.dt)
@@ -187,7 +225,7 @@ class DirectTeleOperation:
 		# rightUntuckedRotation = np.matmul(rightUntuckedRotation.reshape(3,3),
 		# 	rotzm90).flatten()
 		#rightUntuckedTranslation = np.array([0.6410086795413383, -0.196298410887376, 0.8540173127153597])
-		rightUntuckedTranslation = np.array([0.34,
+		rightUntuckedTranslation = np.array([0.54,
 			-0.296298410887376, 0.8540173127153597])
 		# Looks like the y axis is the left-right axis.
 		# Mirroring along y axis.
@@ -208,29 +246,54 @@ class DirectTeleOperation:
 		#TODO REMOVE JANKINESS - Jing-Chen
 		self.tool = np.array([0,0,0])
 
-		if('left_limb' in self.components):
+		if self.left_limb.active:
 			#self.robot.setLeftLimbPositionLinear(leftUntuckedConfig,2)
-			self.robot.setLeftEEInertialTransform([leftUntuckedRotation.tolist(),leftUntuckedTranslation.tolist()],2)
-		if('right_limb' in self.components):
+			self.left_limb.setEEInertialTransform([leftUntuckedRotation.tolist(),leftUntuckedTranslation.tolist()],2)
+		if self.right_limb.active:
 			#self.robot.setRightLimbPositionLinear(rightUntuckedConfig,2)
-			self.robot.setRightEEInertialTransform([rightUntuckedRotation.tolist(),rightUntuckedTranslation.tolist()],2)
+			self.right_limb.setEEInertialTransform([rightUntuckedRotation.tolist(),rightUntuckedTranslation.tolist()],2)
 
 
 	def UIStateLogic(self):
 		if(type(self.UI_state)!= int):
 			if self.UI_state["controllerButtonState"]["leftController"]["press"][0] == True :
 				self.setRobotToDefault()
-				self.teleoperationState = 1
-			if (self.UI_state["controllerButtonState"]["leftController"]["press"][1] == True and self.teleoperationState == 1):
-				print('\n\n\n\n resetting UI initial state \n\n\n\n\n')
-				self.init_UI_state = self.UI_state
-				self.init_headset_orientation = self.treat_headset_orientation(self.UI_state['headSetPositionState']['deviceRotation'])
-				self.init_pos_right = self.robot.sensedRightEETransform()
-				self.init_pos_left = self.robot.sensedLeftEETransform()
-				self.teleoperationState = 2
+				self.left_limb.teleoperationState = 1
+				self.right_limb.teleoperationState = 1
+			if self.controller_mode == ControllerMode.ABSOLUTE:
+				if (self.UI_state["controllerButtonState"]["leftController"]["press"][1] == True and self.left_limb.teleoperationState == 1):
+					print('\n\n\n\n resetting UI initial state \n\n\n\n\n')
+					self.init_UI_state = self.UI_state
+					self.init_headset_orientation = self.treat_headset_orientation(self.UI_state['headSetPositionState']['deviceRotation'])
+
+					for limb in (self.left_limb, self.right_limb):
+						limb.init_pos = limb.sensedEETransform()
+						limb.teleoperationState = 2
+
+			elif self.controller_mode == ControllerMode.CLUTCHING:
+				for limb in (self.left_limb, self.right_limb):
+					if self.UI_state["controllerButtonState"][limb.joystick]["squeeze"][1] > 0.5:
+						if limb.teleoperationState == 1:
+							self.init_UI_state["controllerPositionState"][limb.joystick]["controllerPosition"] = (
+								self.UI_state["controllerPositionState"][limb.joystick]["controllerPosition"])
+							self.init_UI_state["controllerPositionState"][limb.joystick]['controllerRotation'] = (
+								self.UI_state["controllerPositionState"][limb.joystick]['controllerRotation'])
+
+							#self.init_headset_orientation = self.treat_headset_orientation(self.UI_state['headSetPositionState']['deviceRotation'])
+							self.init_headset_orientation = R.from_dcm([[1, 0, 0],[0, 1, 0], [0, 0, 1]])
+
+							limb.init_pos = limb.sensedEETransform()
+
+							print("BEGIN CLUTCHING, ZERO!")
+
+							limb.teleoperationState = 2
+
+					else:
+						limb.teleoperationState = 1
 
 			if(self.base_active):
 				self.baseControl()
+
 			self.control('velocity')
 
 
@@ -248,59 +311,68 @@ class DirectTeleOperation:
 				pass
 
 	def control(self, mode):
-		if(self.left_limb_active):
-			self.controlArm('left', mode)
+		if self.left_limb.active and self.left_limb.teleoperationState == 2:
+			self.controlArm(self.left_limb, mode)
 			self.temp_robot_telemetry['leftArm'] = self.robot.sensedLeftLimbPosition()
-		if(self.right_limb_active):
-			self.controlArm('right', mode)
+		if self.right_limb.active and self.right_limb.teleoperationState == 2:
+			self.controlArm(self.left_limb, mode)
 			self.temp_robot_telemetry['rightArm'] = self.robot.sensedRightLimbPosition()
+
+		if (self.mode == 'Physical') and self.left_limb.gripper_active and self.left_limb.teleoperationState == 2:
+			pass
+
+			closed_value = self.UI_state["controllerButtonState"]["leftController"]["squeeze"][0]
+			if(closed_value > 0):
+				self.robot.closeLeftRobotiqGripper()
+			else:
+				self.robot.openLeftRobotiqGripper()
+
 		self.robot.addRobotTelemetry(self.temp_robot_telemetry)
 
-	def controlArm(self, side, mode):
-		joystick = side+"Controller"
-		assert (side in ['left','right']), "invalid arm selection"
+	"""
+	Control an arm based on UI state and other jazz. Might lock it.
+	
+	limb: Arm object.
+	mode: One of position, velocity, or impedance.
+	"""
+	def controlArm(self, limb, mode):
 		assert (mode in ['position', 'velocity', 'impedance']), "Invalid mode"
-		actual_dt = 3 * self.dt
-		gain = 2.0
-		if self.UI_state["controllerButtonState"][joystick]["squeeze"][1] > 0.5 and self.teleoperationState == 2:
-			RR_final, RT_final, curr_transform = self.getEETransform(side)
-			trans = (RR_final, RT_final)
+		if self.UI_state["controllerButtonState"][limb.joystick]["squeeze"][1] > 0.5:
+			print("DRIVE LIMB " + limb.side)
+
+			RR_final, RT_final, curr_transform = self.getTargetEETransform(limb)
+			print("TARGET TRANSFORM:")
+			print(RR_final)
+			print(RT_final)
+			print("CURRENT TRANSFORM:")
+			print(curr_transform)
+			print("RAW: ")
+			print(np.array(self.UI_state["controllerPositionState"]
+				[limb.joystick]["controllerPosition"]))
+			print("HOMED:")
+			print(np.array(self.init_UI_state["controllerPositionState"]
+				[limb.joystick]["controllerPosition"]))
+
+			target_transform = (RR_final, RT_final)
+			actual_dt = 1 * self.dt
+			gain = 2.0
 			error = vectorops.mul(se3.error((RR_final, RT_final), curr_transform), gain)
 			# Set EE Velocity wants (v, w), error gives (w, v)
-			error_t = error[3:]
-			error_t.extend(error[:3])
-			if(side == 'right'):
-				if mode == 'position':
-					self.robot.setRightEEInertialTransform(
-						trans, actual_dt)
-				elif mode == 'velocity':
-					self.robot.setRightEEVelocity(error_t, tool = self.tool.tolist())
-				elif mode == 'impedance':
-					self.robot.setRightEETransformImpedance(trans, self.K,
-						self.M, self.B)
-			else:
-				if mode == 'position':
-					self.robot.setLeftEEInertialTransform(
-						trans, actual_dt)
-				elif mode == 'velocity':
-					self.robot.setLeftEEVelocity(error_t, tool = self.tool.tolist())
-				elif mode == 'impedance':
-					self.robot.setLeftEETransformImpedance(trans, self.K,
-						self.M, self.B)
-				if((self.mode == 'Physical') and self.left_gripper_active):
-					closed_value = self.UI_state["controllerButtonState"]["leftController"]["squeeze"][0]
-					if(closed_value > 0):
-						self.robot.closeLeftRobotiqGripper()
-					else:
-						self.robot.openLeftRobotiqGripper()
-			err = self.tool_target - self.tool
-		elif self.teleoperationState == 2:
-			if side == 'right':
-				self.robot.setRightEEVelocity([0,0,0,0,0,0], tool = self.tool.tolist())
-			elif side == 'left':
-				self.robot.setLeftEEVelocity([0,0,0,0,0,0], tool = self.tool.tolist())
+			error_t = error[3:] + error[:3]
+			if mode == 'position':
+				limb.setEEInertialTransform(target_transform, actual_dt)
+			elif mode == 'velocity':
+				limb.setEEVelocity(error_t, tool = self.tool.tolist())
+			elif mode == 'impedance':
+				limb.setEETransformImpedance(target_transform, self.K, self.M, self.B)
 
-	def getEETransform(self, side):
+            #TODO remove jankness - Jing-Chen
+			err = self.tool_target - self.tool
+			self.tool = np.add(self.tool, 0.1 * err, out=self.tool, casting="unsafe")
+		else:
+			limb.setEEVelocity([0,0,0,0,0,0], tool = self.tool.tolist())
+
+	def getTargetEETransform(self, limb):
 		"""Get the transform of the end effector attached to the `side` arm
 		in the frame of the <base?> of the robot.
 
@@ -322,7 +394,7 @@ class DirectTeleOperation:
 
 		Parameters
 		----------------
-		side: str: ['left', 'right']
+		limb: limb object
 			Which arm to compute transform for.
 
 		Returns
@@ -332,19 +404,15 @@ class DirectTeleOperation:
 			requested arm, (R,t) tuple representing the current transform of
 			the requested arm
 		"""
-		joystick = side+"Controller"
 		R_cw_rw = np.array([[0,0,1],[-1,0,0],[0,1,0]])
-		if(side == 'right'):
-			[RR_rw_rh,RT_rw_rh] = self.init_pos_right
-			curr_transform = self.robot.sensedRightEETransform()
-		elif(side == 'left'):
-			[RR_rw_rh,RT_rw_rh] = self.init_pos_left
-			curr_transform = self.robot.sensedLeftEETransform()
+		[RR_rw_rh,RT_rw_rh] = limb.init_pos
+		curr_transform = limb.sensedEETransform()
+
 		RT_rw_rh = np.array(RT_rw_rh)
 		RT_cw_cc = np.array(self.UI_state["controllerPositionState"]
-			[joystick]["controllerPosition"])
+			[limb.joystick]["controllerPosition"])
 		RT_cw_ch = np.array(self.init_UI_state["controllerPositionState"]
-			[joystick]["controllerPosition"])
+			[limb.joystick]["controllerPosition"])
 		RT_final = ( RT_rw_rh
 			+ (np.matmul(
 			np.matmul(self.init_headset_orientation.as_dcm(),R_cw_rw)
@@ -356,7 +424,7 @@ class DirectTeleOperation:
 
 		init_quat = np.array(
 			self.init_UI_state["controllerPositionState"]
-				[joystick]['controllerRotation'])
+				[limb.joystick]['controllerRotation'])
 
 		R_cw_rw = R.from_dcm(R_cw_rw)
 
@@ -368,7 +436,7 @@ class DirectTeleOperation:
 			[-init_quat[2],init_quat[0],-init_quat[1]]) * (-init_angle)
 
 		#transform it to right handed:
-		curr_quat = np.array(self.UI_state["controllerPositionState"][joystick]
+		curr_quat = np.array(self.UI_state["controllerPositionState"][limb.joystick]
 			['controllerRotation'])
 		curr_angle = (np.pi/180)*curr_quat[3]
 		right_handed_curr_vec = np.array(

--- a/trina_modules/DirectTeleOperationModule/DirectTeleOperationFile.py
+++ b/trina_modules/DirectTeleOperationModule/DirectTeleOperationFile.py
@@ -273,7 +273,7 @@ class DirectTeleOperation:
 			elif self.controller_mode == ControllerMode.CLUTCHING:
 				for limb in (self.left_limb, self.right_limb):
 					if self.UI_state["controllerButtonState"][limb.joystick]["squeeze"][1] > 0.5:
-						if limb.teleoperationState == 1:
+						if limb.teleoperationState == 3 or limb.teleoperationState == 1:
 							self.init_UI_state["controllerPositionState"][limb.joystick]["controllerPosition"] = (
 								self.UI_state["controllerPositionState"][limb.joystick]["controllerPosition"])
 							self.init_UI_state["controllerPositionState"][limb.joystick]['controllerRotation'] = (
@@ -288,8 +288,9 @@ class DirectTeleOperation:
 
 							limb.teleoperationState = 2
 
-					else:
-						limb.teleoperationState = 1
+					elif limb.teleoperationState == 2:
+						limb.teleoperationState = 3
+						limb.setEEVelocity([0,0,0,0,0,0], tool = self.tool.tolist())
 
 			if(self.base_active):
 				self.baseControl()
@@ -366,7 +367,7 @@ class DirectTeleOperation:
 			elif mode == 'impedance':
 				limb.setEETransformImpedance(target_transform, self.K, self.M, self.B)
 
-            #TODO remove jankness - Jing-Chen
+            #TODO remove jankness - Jing-Chen is this even doing anything??
 			err = self.tool_target - self.tool
 			self.tool = np.add(self.tool, 0.1 * err, out=self.tool, casting="unsafe")
 		else:

--- a/trina_modules/UI/UI_end_1.py
+++ b/trina_modules/UI/UI_end_1.py
@@ -369,6 +369,8 @@ class UI_end_1:
         self.screenElement = set([])
         if "--teleop" in args:
             self.jarvis.changeActivityStatus(["DirectTeleOperation"])
+        if "--testing" in args:
+            self.jarvis.changeActivityStatus(["testing"])
         if not "--trigger" in args:
             file_dir = "../../Motion/data/TRINA_world_anthrax_PointClick.xml"
             world = klampt.WorldModel()


### PR DESCRIPTION
The motion changes are totally separate from the DirectTeleOp ones so if we don't want that I can roll them all back, after as much testing as I could get in simulation they behave the same.

Notably the jacobian stuff in CartesianDrive is causing the robot to fail/flail around when it hits unsolvable configs in the kinematic simulation, and it really likes to go to [0, 0, 0, 0, 0, 0], which would be really bad IRL...